### PR TITLE
Remove Project Shield as CPPSes are usually gaming sites

### DIFF
--- a/EXTRA-STUFF/Admin Tools/DDOS Protection.txt
+++ b/EXTRA-STUFF/Admin Tools/DDOS Protection.txt
@@ -3,7 +3,6 @@ https://javapipe.com/ddos/remote-protection/
 https://www.incapsula.com/ddos-protection-services.html
 https://bitmitigate.com/ (Pretty bad though)
 https://bitninja.io/ (Apparently spammed emails)
-https://projectshield.withgoogle.com/public/
 
 What not to get:
 Vultr DDOS protection ($10 month for nothing. Can't even block 400MB attack.)


### PR DESCRIPTION
From Google's website:

Do I qualify?

Project Shield welcomes applications from news, human rights, or elections monitoring organizations and individual journalists. We do not provide service to other types of content, including gaming sites and businesses. See our User Content and Conduct Policy for more details.